### PR TITLE
 Reduce time between logs

### DIFF
--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -787,7 +787,7 @@ void FastText::startThreads() {
   const int64_t ntokens = dict_->ntokens();
   // Same condition as trainThread
   while (tokenCount_ < args_->epoch * ntokens) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(30000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
     if (loss_ >= 0 && args_->verbose > 1) {
       real progress = real(tokenCount_) / (args_->epoch * ntokens);
       std::cerr << "\n";


### PR DESCRIPTION
This logging happens on the main thread so runtime will never be lower than this interval